### PR TITLE
WIP bumps comscore to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,21 @@ comScore integration for [analytics-android](https://github.com/segmentio/analyt
 
 ## Installation
 
-To install the Segment-comScore integration, simply add this line to your gradle file:
+To install the Segment-comScore integration, simply add the following to your gradle file:
 
 
 ```
 compile 'com.segment.analytics.android.integrations:comscore:1.0.2'
+```
+
+```
+allprojects {
+  repositories {
+    maven {
+      url "https://comscore.bintray.com/Analytics"
+    }
+  }
+}
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.comscore:android-analytics:5.+'
+  compile 'com.comscore:android-analytics:5.1.0'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ checkstyle {
   configFile rootProject.file('gradle/checkstyle.xml')
 }
 
+allprojects {
+  repositories {
+    maven {
+      url "https://comscore.bintray.com/Analytics"
+    }
+  }
+}
+
 dependencies {
   repositories {
     mavenCentral()
@@ -40,7 +48,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile files('libs/comscore.jar')
+  compile "com.comscore:android-analytics:5.+"
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -6,12 +6,14 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:1.3.1'
     classpath 'com.f2prateek.checkstyle:checkstyle:1.0.1'
+    classpath 'com.f2prateek.javafmt:javafmt:0.1.4'
   }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 apply plugin: 'com.f2prateek.checkstyle'
+apply plugin: 'com.f2prateek.javafmt'
 
 android {
   compileSdkVersion 23
@@ -56,7 +58,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile "com.comscore:android-analytics:5.+"
+  compile 'com.comscore:android-analytics:5.+'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,14 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
   }
+
+  testOptions {
+    unitTests {
+      all {
+        jvmArgs '-noverify'
+      }
+    }
+  }
 }
 
 checkstyle {

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -9,20 +9,21 @@ import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
-
 import java.util.HashMap;
 
 public class ComScoreIntegration extends Integration<Void> {
-  public static final Factory FACTORY = new Factory() {
-    @Override public Integration<?>
-    create(ValueMap settings, com.segment.analytics.Analytics analytics) {
-      return new ComScoreIntegration(analytics, settings);
-    }
+  public static final Factory FACTORY =
+      new Factory() {
+        @Override
+        public Integration<?> create(ValueMap settings, com.segment.analytics.Analytics analytics) {
+          return new ComScoreIntegration(analytics, settings);
+        }
 
-    @Override public String key() {
-      return COMSCORE_KEY;
-    }
-  };
+        @Override
+        public String key() {
+          return COMSCORE_KEY;
+        }
+      };
 
   private static final String COMSCORE_KEY = "comScore";
   final Logger logger;
@@ -34,7 +35,6 @@ public class ComScoreIntegration extends Integration<Void> {
   boolean autoUpdate;
   boolean foregroundOnly;
 
-
   ComScoreIntegration(com.segment.analytics.Analytics analytics, ValueMap settings) {
     logger = analytics.logger(COMSCORE_KEY);
     customerC2 = settings.getString("c2");
@@ -45,40 +45,41 @@ public class ComScoreIntegration extends Integration<Void> {
     autoUpdate = settings.getBoolean("autoUpdate", false);
     foregroundOnly = settings.getBoolean("foregroundOnly", true);
 
-        PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
-        builder.publisherId(customerC2);
-        builder.publisherSecret(publisherSecret);
-      if (appName != null && appName.trim().length() == 0) {
-        builder.applicationName(appName);
-      }
-        builder.secureTransmission(useHTTPS);
-        builder.usagePropertiesAutoUpdateInterval(autoUpdateInterval);
+    PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
+    builder.publisherId(customerC2);
+    builder.publisherSecret(publisherSecret);
+    if (appName != null && appName.trim().length() == 0) {
+      builder.applicationName(appName);
+    }
+    builder.secureTransmission(useHTTPS);
+    builder.usagePropertiesAutoUpdateInterval(autoUpdateInterval);
 
-      if (autoUpdate) {
-        builder.usagePropertiesAutoUpdateMode(
-            UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND
-        );
-      } else if (foregroundOnly) {
-        builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
-      } else {
-        builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
-      }
+    if (autoUpdate) {
+      builder.usagePropertiesAutoUpdateMode(
+          UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
+    } else if (foregroundOnly) {
+      builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
+    } else {
+      builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
+    }
 
-      PublisherConfiguration myPublisherConfig = builder.build();
+    PublisherConfiguration myPublisherConfig = builder.build();
 
-      Analytics.getConfiguration().addClient(myPublisherConfig);
-      Analytics.start(analytics.getApplication());
+    Analytics.getConfiguration().addClient(myPublisherConfig);
+    Analytics.start(analytics.getApplication());
   }
 
-  @Override public void track(TrackPayload track) {
+  @Override
+  public void track(TrackPayload track) {
     String name = track.event();
     HashMap<String, String> properties = (HashMap<String, String>) track.properties().toStringMap();
     properties.put("name", name);
-      Analytics.notifyHiddenEvent(properties);
+    Analytics.notifyHiddenEvent(properties);
     logger.verbose("Analytics.hidden(%s)", properties);
   }
 
-  @Override public void identify(IdentifyPayload identify) {
+  @Override
+  public void identify(IdentifyPayload identify) {
     super.identify(identify);
     String userId = identify.userId();
     HashMap<String, String> traits = (HashMap<String, String>) identify.traits().toStringMap();
@@ -87,16 +88,16 @@ public class ComScoreIntegration extends Integration<Void> {
     logger.verbose("Analytics.setPersistentLabels(%s)", traits);
   }
 
-  @Override public void screen(ScreenPayload screen) {
+  @Override
+  public void screen(ScreenPayload screen) {
     String name = screen.name();
     String category = screen.category();
-    HashMap<String, String> properties = (HashMap<String, String>) //
-        screen.properties().toStringMap();
+    HashMap<String, String> properties =
+        (HashMap<String, String>) //
+            screen.properties().toStringMap();
     properties.put("name", name);
     properties.put("category", category);
-
-      Analytics.notifyViewEvent(properties);
+    Analytics.notifyViewEvent(properties);
     logger.verbose("Analytics.notifyViewEvent(%s)", properties);
   }
-
 }

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -14,7 +14,8 @@ import java.util.HashMap;
 
 public class ComScoreIntegration extends Integration<Void> {
   public static final Factory FACTORY = new Factory() {
-    @Override public Integration<?> create(ValueMap settings, com.segment.analytics.Analytics analytics) {
+    @Override public Integration<?>
+    create(ValueMap settings, com.segment.analytics.Analytics analytics) {
       return new ComScoreIntegration(analytics, settings);
     }
 
@@ -51,12 +52,14 @@ public class ComScoreIntegration extends Integration<Void> {
         builder.secureTransmission(useHTTPS);
         builder.usagePropertiesAutoUpdateInterval(autoUpdateInterval);
 
-        if (autoUpdate) {
-          builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
+      if (autoUpdate) {
+        builder.usagePropertiesAutoUpdateMode(
+            UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND
+        );
       } else if (foregroundOnly) {
-          builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
+        builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
       } else {
-          builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
+        builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
       }
 
       PublisherConfiguration myPublisherConfig = builder.build();

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -1,7 +1,6 @@
 package com.segment.analytics.android.integrations.comscore;
 
 import com.comscore.Analytics;
-import com.comscore.Configuration;
 import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.segment.analytics.ValueMap;
@@ -36,7 +35,7 @@ public class ComScoreIntegration extends Integration<Void> {
   boolean foregroundOnly;
 
 
-    ComScoreIntegration(com.segment.analytics.Analytics analytics, ValueMap settings) {
+  ComScoreIntegration(com.segment.analytics.Analytics analytics, ValueMap settings) {
     logger = analytics.logger(COMSCORE_KEY);
     customerC2 = settings.getString("c2");
     publisherSecret = settings.getString("publisherSecret");
@@ -49,7 +48,9 @@ public class ComScoreIntegration extends Integration<Void> {
         PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
         builder.publisherId(customerC2);
         builder.publisherSecret(publisherSecret);
+      if (appName != null && appName.trim().length() == 0) {
         builder.applicationName(appName);
+      }
         builder.secureTransmission(useHTTPS);
         builder.usagePropertiesAutoUpdateInterval(autoUpdateInterval);
 
@@ -65,8 +66,7 @@ public class ComScoreIntegration extends Integration<Void> {
 
       PublisherConfiguration myPublisherConfig = builder.build();
 
-      Configuration configuration = Analytics.getConfiguration();
-      configuration.addClient(myPublisherConfig);
+      Analytics.getConfiguration().addClient(myPublisherConfig);
       Analytics.start(analytics.getApplication());
   }
 
@@ -83,7 +83,7 @@ public class ComScoreIntegration extends Integration<Void> {
     String userId = identify.userId();
     HashMap<String, String> traits = (HashMap<String, String>) identify.traits().toStringMap();
     traits.put("userId", userId);
-      Analytics.getConfiguration().setPersistentLabels(traits);
+    Analytics.getConfiguration().setPersistentLabels(traits);
     logger.verbose("Analytics.setPersistentLabels(%s)", traits);
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -1,5 +1,6 @@
 package com.segment.analytics.android.integrations.comscore;
 
+import com.comscore.Analytics;
 import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.segment.analytics.ValueMap;
@@ -60,15 +61,15 @@ public class ComScoreIntegration extends Integration<Void> {
 
       PublisherConfiguration myPublisherConfig = builder.build();
 
-      com.comscore.Analytics.getConfiguration().addClient(myPublisherConfig);
-      com.comscore.Analytics.start(analytics.getApplication());
+      Analytics.getConfiguration().addClient(myPublisherConfig);
+      Analytics.start(analytics.getApplication());
   }
 
   @Override public void track(TrackPayload track) {
     String name = track.event();
     HashMap<String, String> properties = (HashMap<String, String>) track.properties().toStringMap();
     properties.put("name", name);
-      com.comscore.Analytics.notifyHiddenEvent(properties);
+      Analytics.notifyHiddenEvent(properties);
     logger.verbose("Analytics.hidden(%s)", properties);
   }
 
@@ -77,7 +78,7 @@ public class ComScoreIntegration extends Integration<Void> {
     String userId = identify.userId();
     HashMap<String, String> traits = (HashMap<String, String>) identify.traits().toStringMap();
     traits.put("userId", userId);
-      com.comscore.Analytics.getConfiguration().setPersistentLabels(traits);
+      Analytics.getConfiguration().setPersistentLabels(traits);
     logger.verbose("Analytics.setPersistentLabels(%s)", traits);
   }
 
@@ -89,7 +90,7 @@ public class ComScoreIntegration extends Integration<Void> {
     properties.put("name", name);
     properties.put("category", category);
 
-      com.comscore.Analytics.notifyViewEvent(properties);
+      Analytics.notifyViewEvent(properties);
     logger.verbose("Analytics.notifyViewEvent(%s)", properties);
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -48,7 +48,7 @@ public class ComScoreIntegration extends Integration<Void> {
     PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
     builder.publisherId(customerC2);
     builder.publisherSecret(publisherSecret);
-    if (appName != null && appName.trim().length() == 0) {
+    if (appName != null && appName.trim().length() != 0) {
       builder.applicationName(appName);
     }
     builder.secureTransmission(useHTTPS);

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -1,6 +1,7 @@
 package com.segment.analytics.android.integrations.comscore;
 
 import com.comscore.Analytics;
+import com.comscore.Configuration;
 import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.segment.analytics.ValueMap;
@@ -64,7 +65,8 @@ public class ComScoreIntegration extends Integration<Void> {
 
       PublisherConfiguration myPublisherConfig = builder.build();
 
-      Analytics.getConfiguration().addClient(myPublisherConfig);
+      Configuration configuration = Analytics.getConfiguration();
+      configuration.addClient(myPublisherConfig);
       Analytics.start(analytics.getApplication());
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -1,7 +1,6 @@
 package com.segment.analytics.android.integrations.comscore;
 
 import android.app.Application;
-
 import com.comscore.Configuration;
 import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
@@ -22,13 +21,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
-
 import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static com.segment.analytics.Utils.createTraits;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -4,6 +4,7 @@ package com.segment.analytics.android.integrations.comscore;
 import android.app.Application;
 import android.app.usage.UsageStatsManager;
 
+import com.comscore.Configuration;
 import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.comscore.Analytics;
@@ -45,9 +46,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
   @Rule public PowerMockRule rule = new PowerMockRule();
   @Mock Application context;
+  @Mock Configuration myConfig;
   Logger logger;
-  @Mock
-  com.segment.analytics.Analytics analytics;
+  @Mock com.segment.analytics.Analytics analytics;
   ComScoreIntegration integration;
   @Mock Analytics Comscore;
 
@@ -55,10 +56,10 @@ import static org.powermock.api.mockito.PowerMockito.when;
     initMocks(this);
     mockStatic(Analytics.class);
     logger = Logger.with(com.segment.analytics.Analytics.LogLevel.DEBUG);
-    when(analytics.logger("ComScore")).thenReturn(Logger.with(VERBOSE));
+    when(analytics.logger("comScore")).thenReturn(Logger.with(VERBOSE));
+    when(Analytics.getConfiguration()).thenReturn(myConfig);
     when(analytics.getApplication()).thenReturn(context);
     integration = new ComScoreIntegration(analytics, new ValueMap().putValue("customerC2", "foobarbar").putValue("publisherSecret", "illnevertell"));
-    mockStatic(Analytics.class);
   }
 
   @Test public void factory() {
@@ -85,6 +86,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
   }
 
   @Test public void initializeWithAutoUpdateMode() throws IllegalStateException {
+
     integration = new ComScoreIntegration(analytics, new ValueMap() //
         .putValue("c2", "foobarbar")
         .putValue("publisherSecret", "illnevertell")
@@ -95,16 +97,14 @@ import static org.powermock.api.mockito.PowerMockito.when;
         .putValue("foregroundOnly", true));
 
     PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
-    verifyStatic();
     builder.publisherId("foobarbar");
-    verifyStatic();
     builder.publisherSecret("illnevertell");
-    verifyStatic();
     builder.applicationName("testApp");
-    verifyStatic();
     builder.secureTransmission(true);
-    verifyStatic();
     builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
+    PublisherConfiguration testConfig = builder.build();
+
+    when(Analytics.getConfiguration()).thenReturn(testConfig);
   }
 
 
@@ -149,7 +149,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
     expected.put("userId", "foo");
 
     verifyStatic();
-      Analytics.getConfiguration().setPersistentLabels(expected);
+    Analytics.getConfiguration().setPersistentLabels(expected);
   }
 
   @Test public void screen() {

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -2,8 +2,11 @@ package com.segment.analytics.android.integrations.comscore;
 
 
 import android.app.Application;
-import com.comscore.analytics.comScore;
-import com.segment.analytics.Analytics;
+import android.app.usage.UsageStatsManager;
+
+import com.comscore.PublisherConfiguration;
+import com.comscore.UsagePropertiesAutoUpdateMode;
+import com.comscore.Analytics;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
@@ -38,23 +41,24 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 @PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*" })
-@PrepareForTest(comScore.class) public class ComScoreTest {
+@PrepareForTest(Analytics.class) public class ComScoreTest {
 
   @Rule public PowerMockRule rule = new PowerMockRule();
   @Mock Application context;
   Logger logger;
-  @Mock Analytics analytics;
+  @Mock
+  com.segment.analytics.Analytics analytics;
   ComScoreIntegration integration;
-  @Mock comScore Comscore;
+  @Mock Analytics Comscore;
 
   @Before public void setUp() {
     initMocks(this);
-    mockStatic(comScore.class);
-    logger = Logger.with(Analytics.LogLevel.DEBUG);
+    mockStatic(Analytics.class);
+    logger = Logger.with(com.segment.analytics.Analytics.LogLevel.DEBUG);
     when(analytics.logger("ComScore")).thenReturn(Logger.with(VERBOSE));
     when(analytics.getApplication()).thenReturn(context);
     integration = new ComScoreIntegration(analytics, new ValueMap().putValue("customerC2", "foobarbar").putValue("publisherSecret", "illnevertell"));
-    mockStatic(comScore.class);
+    mockStatic(Analytics.class);
   }
 
   @Test public void factory() {
@@ -90,18 +94,17 @@ import static org.powermock.api.mockito.PowerMockito.when;
         .putValue("autoUpdate", true)
         .putValue("foregroundOnly", true));
 
+    PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder();
     verifyStatic();
-    comScore.setAppContext(analytics.getApplication());
+    builder.publisherId("foobarbar");
     verifyStatic();
-    comScore.setCustomerC2("foobarbar");
+    builder.publisherSecret("illnevertell");
     verifyStatic();
-    comScore.setPublisherSecret("illnevertell");
+    builder.applicationName("testApp");
     verifyStatic();
-    comScore.setAppName("testApp");
+    builder.secureTransmission(true);
     verifyStatic();
-    comScore.setSecure(true);
-    verifyStatic();
-    comScore.enableAutoUpdate(2000, true);
+    builder.usagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
   }
 
 
@@ -111,7 +114,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
     Properties expected = new Properties().putValue("name", "foo");
     Map<String, String> properties = expected.toStringMap();
     verifyStatic();
-    comScore.hidden((HashMap<String, String>) properties);
+    Analytics.notifyHiddenEvent((HashMap<String, String>) properties);
   }
 
   @Test public void trackWithProps() {
@@ -128,7 +131,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
     expected.put("product", "Ukelele");
 
     verifyStatic();
-    comScore.hidden(expected);
+    Analytics.notifyHiddenEvent(expected);
   }
 
   @Test public void identify() throws JSONException {
@@ -146,7 +149,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
     expected.put("userId", "foo");
 
     verifyStatic();
-    comScore.setLabels(expected);
+      Analytics.getConfiguration().setPersistentLabels(expected);
   }
 
   @Test public void screen() {
@@ -157,6 +160,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
     expected.put("category", "Purchase Screen");
 
     verifyStatic();
-    comScore.view(expected);
+      Analytics.notifyViewEvent(expected);
   }
 }


### PR DESCRIPTION
Hit some blocks here, mainly unsure of how to set `usagePropertiesAutoUpdateMode` to `ForegroundOnly`, `ForegroundAndBackground`, or `Disabled` in builder method

why getApplicationContext isn't found
`com.comscore.Analytics.start(this.getApplicationContext());`

comScore is also named `Analytics` so for example, instead of `Analytics.getConfiguration().addClient(myPublisherConfig);` I specify `com.comscore.Analytics.getConfiguration().addClient(myPublisherConfig);`

Also need to confirm w/ comScore on screen and track as it is not documented. I could see the more similar syntax for hidden -> was notifyHiddenEvent and view -> notifyViewEvent. 