### PR TITLE
Add snake case property support

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -129,12 +129,12 @@ public class ComScoreIntegration extends Integration<Void> {
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
     String contentAssetId = properties.getString("assetId");
+    if (contentAssetId == null || contentAssetId.trim().isEmpty()) {
+      contentAssetId = properties.getString("asset_id");
       if (contentAssetId == null || contentAssetId.trim().isEmpty()) {
-        contentAssetId = properties.getString("asset_id");
-        if (contentAssetId == null || contentAssetId.trim().isEmpty()) {
-          contentAssetId = "0";
-        }
+        contentAssetId = "0";
       }
+    }
     asset.put("ns_st_ci", String.valueOf(contentAssetId));
 
     if (properties.containsKey("totalLength") || properties.containsKey("total_length")) {

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -106,6 +106,9 @@ public class ComScoreIntegration extends Integration<Void> {
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
     boolean fullScreen = properties.getBoolean("fullScreen", false);
+    if (fullScreen == false) {
+      fullScreen =  properties.getBoolean("full_screen", false);
+    }
     asset.put("ns_st_ws", fullScreen ? "full" : "norm");
 
     int bitrate = properties.getInt("bitrate", 0) * 1000; // comScore expects bps.
@@ -126,10 +129,16 @@ public class ComScoreIntegration extends Integration<Void> {
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
     int contentAssetId = properties.getInt("assetId", 0);
+    if (contentAssetId == 0) {
+      contentAssetId = properties.getInt("asset_id", 0);
+    }
     asset.put("ns_st_ci", String.valueOf(contentAssetId));
 
-    if (properties.containsKey("totalLength")) {
+    if (properties.containsKey("totalLength" || properties.containsKey("total_length")) {
       int length = properties.getInt("totalLength", 0) * 1000; // comScore expects milliseconds.
+      if (length == 0) {
+        length = properties.getInt("total_length", 0) * 1000;
+      }
       asset.put("ns_st_cl", String.valueOf(length));
     }
 
@@ -164,8 +173,11 @@ public class ComScoreIntegration extends Integration<Void> {
 
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
-    if (properties.containsKey("totalLength")) {
+    if (properties.containsKey("totalLength") || properties.containsKey("total_length")) {
       int length = properties.getInt("totalLength", 0) * 1000; // comScore expects milliseconds.
+      if (length == 0) {
+        length = properties.getInt("total_length", 0) * 1000;
+      }
       asset.put("ns_st_cl", String.valueOf(length));
     }
 
@@ -217,9 +229,13 @@ public class ComScoreIntegration extends Integration<Void> {
           TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
+    if (playbackPosition == 0) {
+      playbackPosition = properties.getLong("position", 0);
+    }
 
     Map<String, String> playbackMapper = new LinkedHashMap<>();
     playbackMapper.put("videoPlayer", "ns_st_mp");
+    playbackMapper.put("video_player", "ns_st_mp");
     playbackMapper.put("sound", "ns_st_vo");
 
     Map<String, String> mappedPlaybackProperties =
@@ -233,6 +249,7 @@ public class ComScoreIntegration extends Integration<Void> {
       // The label ns_st_ci must be set through a setAsset call
       Map<String, String> contentIdMapper = new LinkedHashMap<>();
       contentIdMapper.put("assetId", "ns_st_ci");
+      contentIdMapper.put("asset_id", "ns_st_ci");
 
       Map<String, String> mappedContentProperties = mapSpecialKeys(properties, contentIdMapper);
 
@@ -285,6 +302,9 @@ public class ComScoreIntegration extends Integration<Void> {
           TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
+    if (playbackPosition == 0) {
+      playbackPosition = properties.getLong("position", 0);
+    }
 
     Map<String, String> contentMapper = new LinkedHashMap<>();
     contentMapper.put("title", "ns_st_ep");
@@ -295,7 +315,9 @@ public class ComScoreIntegration extends Integration<Void> {
     contentMapper.put("channel", "ns_st_st");
     contentMapper.put("publisher", "ns_st_pu");
     contentMapper.put("fullEpisode", "ns_st_ce");
+    contentMapper.put("full_episode", "ns_st_ce");
     contentMapper.put("podId", "ns_st_pn");
+    contentMapper.put("pod_id", "ns_st_pn");
 
     Map<String, String> mappedContentProperties =
             mapContentProperties(properties, comScoreOptions, contentMapper);
@@ -341,9 +363,13 @@ public class ComScoreIntegration extends Integration<Void> {
           TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
+    if (playbackPosition == 0) {
+      playbackPosition = properties.getLong("position", 0);
+    }
 
     Map<String, String> adMapper = new LinkedHashMap<>();
     adMapper.put("assetId", "ns_st_ami");
+    adMapper.put("asset_id", "ns_st_ami");
     adMapper.put("title", "ns_st_amt");
     adMapper.put("publisher", "ns_st_pu");
 

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -134,7 +134,7 @@ public class ComScoreIntegration extends Integration<Void> {
     }
     asset.put("ns_st_ci", String.valueOf(contentAssetId));
 
-    if (properties.containsKey("totalLength" || properties.containsKey("total_length")) {
+    if (properties.containsKey("totalLength") || properties.containsKey("total_length")) {
       int length = properties.getInt("totalLength", 0) * 1000; // comScore expects milliseconds.
       if (length == 0) {
         length = properties.getInt("total_length", 0) * 1000;

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -128,10 +128,13 @@ public class ComScoreIntegration extends Integration<Void> {
 
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
-    int contentAssetId = properties.getInt("assetId", 0);
-    if (contentAssetId == 0) {
-      contentAssetId = properties.getInt("asset_id", 0);
-    }
+    String contentAssetId = properties.getString("assetId");
+      if (contentAssetId == null || contentAssetId.trim().isEmpty()) {
+        contentAssetId = properties.getString("asset_id");
+        if (contentAssetId == null || contentAssetId.trim().isEmpty()) {
+          contentAssetId = "0";
+        }
+      }
     asset.put("ns_st_ci", String.valueOf(contentAssetId));
 
     if (properties.containsKey("totalLength") || properties.containsKey("total_length")) {

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -200,12 +200,12 @@ public class ComScoreTest {
     expected.put("c6", "and another one");
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
-            .properties(new Properties().putValue("assetId", 1234)
-                    .putValue("adType", "pre-roll")
-                    .putValue("totalLength", 120)
-                    .putValue("videoPlayer", "youtube")
+            .properties(new Properties().putValue("asset_id", 1234)
+                    .putValue("ad_type", "pre-roll")
+                    .putValue("total_length", 120)
+                    .putValue("video_player", "youtube")
                     .putValue("sound", 80)
-                    .putValue("fullScreen", false)
+                    .putValue("full_screen", false)
                     .putValue("c3", "some value")
                     .putValue("c4", "another value")
                     .putValue("c6", "and another one"))
@@ -224,13 +224,13 @@ public class ComScoreTest {
   @Test
   public void videoPlaybackStarted() {
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
-            .properties(new Properties().putValue("assetId", 1234)
-                    .putValue("adType", "pre-roll")
-                    .putValue("totalLength", 120)
-                    .putValue("videoPlayer", "youtube")
+            .properties(new Properties().putValue("asset_id", 1234)
+                    .putValue("ad_type", "pre-roll")
+                    .putValue("total_length", 120)
+                    .putValue("video_player", "youtube")
                     .putValue("sound", 80)
                     .putValue("bitrate", 40)
-                    .putValue("fullScreen", true))
+                    .putValue("full_screen", true))
             .build());
 
     Map<String, String> contentIdMapper = new LinkedHashMap<>();
@@ -326,12 +326,12 @@ public class ComScoreTest {
     setupWithVideoPlaybackStarted();
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Buffer Completed")
-            .properties(new Properties().putValue("assetId", 1029)
-                    .putValue("adType", "pre-roll")
-                    .putValue("totalLength", 800)
-                    .putValue("videoPlayer", "vimeo")
-                    .putValue("playbackPosition", 30)
-                    .putValue("fullScreen", true)
+            .properties(new Properties().putValue("asset_id", 1029)
+                    .putValue("ad_type", "pre-roll")
+                    .putValue("total_length", 800)
+                    .putValue("video_player", "vimeo")
+                    .putValue("position", 30)
+                    .putValue("full_screen", true)
                     .putValue("bitrate", 500)
                     .putValue("sound", 80))
             .build());
@@ -354,12 +354,12 @@ public class ComScoreTest {
   public void videoPlaybackSeekStarted() {
     setupWithVideoPlaybackStarted();
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Seek Started")
-            .properties(new Properties().putValue("assetId", 3948)
-                    .putValue("adType", "mid-roll")
-                    .putValue("totalLength", 900)
-                    .putValue("videoPlayer", "youtube")
-                    .putValue("playbackPosition", 40)
-                    .putValue("fullScreen", true)
+            .properties(new Properties().putValue("asset_id", 3948)
+                    .putValue("ad_type", "mid-roll")
+                    .putValue("total_length", 900)
+                    .putValue("video_player", "youtube")
+                    .putValue("position", 40)
+                    .putValue("full_screen", true)
                     .putValue("bitrate", 500)
                     .putValue("sound", 80))
             .build());
@@ -497,10 +497,10 @@ public class ComScoreTest {
                     .putValue("program", "Rick and Morty")
                     .putValue("channel", "cartoon network")
                     .putValue("publisher", "Turner Broadcasting System")
-                    .putValue("fullEpisode", true)
-                    .putValue("podId", "segment A")
-                    .putValue("totalLength", "120")
-                    .putValue("playbackPosition", 70))
+                    .putValue("full_episode", true)
+                    .putValue("pod_id", "segment A")
+                    .putValue("total_length", "120")
+                    .putValue("position", 70))
             .integration("comScore", comScoreOptions)
             .build());
 
@@ -627,11 +627,11 @@ public class ComScoreTest {
     setupWithVideoPlaybackStarted();
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started")
-            .properties(new Properties().putValue("assetId", 4311)
-                    .putValue("podId", "adSegmentA")
+            .properties(new Properties().putValue("asset_id", 4311)
+                    .putValue("pod_id", "adSegmentA")
                     .putValue("type", "pre-roll")
-                    .putValue("totalLength", 120)
-                    .putValue("playbackPosition", 0)
+                    .putValue("total_length", 120)
+                    .putValue("position", 0)
                     .putValue("title", "Helmet Ad"))
             .build());
 
@@ -685,11 +685,11 @@ public class ComScoreTest {
     comScoreOptions.put("adClassificationType", "va14");
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started")
-            .properties(new Properties().putValue("assetId", 4311)
-                    .putValue("podId", "adSegmentA")
+            .properties(new Properties().putValue("asset_id", 4311)
+                    .putValue("pod_id", "adSegmentA")
                     .putValue("type", "pre-roll")
-                    .putValue("totalLength", 120)
-                    .putValue("playbackPosition", 0)
+                    .putValue("total_length", 120)
+                    .putValue("position", 0)
                     .putValue("title", "Helmet Ad"))
             .integration("comScore", comScoreOptions)
             .build());

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -190,6 +190,15 @@ public class ComScoreTest {
 
   @Test
   public void setupWithVideoPlaybackStarted() {
+    setupWithVideoPlaybackStarted(false);
+  }
+
+  @Test
+  public void setupWithVideoPlaybackStartedCamelCase() {
+    setupWithVideoPlaybackStarted(true);
+  }
+
+  private void setupWithVideoPlaybackStarted(boolean useCamelCaseProperties) {
     LinkedHashMap<String, String> expected = new LinkedHashMap<>();
     expected.put("ns_st_mp", "youtube");
     expected.put("ns_st_vo", "80");
@@ -199,17 +208,33 @@ public class ComScoreTest {
     expected.put("c4", "another value");
     expected.put("c6", "and another one");
 
-    integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
-            .properties(new Properties().putValue("asset_id", 1234)
-                    .putValue("ad_type", "pre-roll")
-                    .putValue("total_length", 120)
-                    .putValue("video_player", "youtube")
-                    .putValue("sound", 80)
-                    .putValue("full_screen", false)
-                    .putValue("c3", "some value")
-                    .putValue("c4", "another value")
-                    .putValue("c6", "and another one"))
-            .build());
+    // Both camel case and snake case properties should be supported.
+    if (useCamelCaseProperties) {
+      integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
+              .properties(new Properties().putValue("assetId", 1234)
+                      .putValue("adType", "pre-roll")
+                      .putValue("totalLength", 120)
+                      .putValue("videoPlayer", "youtube")
+                      .putValue("sound", 80)
+                      .putValue("fullScreen", false)
+                      .putValue("c3", "some value")
+                      .putValue("c4", "another value")
+                      .putValue("c6", "and another one"))
+              .build());
+    } else {
+      integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
+              .properties(new Properties().putValue("asset_id", 1234)
+                      .putValue("ad_type", "pre-roll")
+                      .putValue("total_length", 120)
+                      .putValue("video_player", "youtube")
+                      .putValue("sound", 80)
+                      .putValue("full_screen", false)
+                      .putValue("c3", "some value")
+                      .putValue("c4", "another value")
+                      .putValue("c6", "and another one"))
+              .build());
+    }
+
 
     Map<String, String> contentIdMapper = new LinkedHashMap<>();
     contentIdMapper.put("ns_st_ci", "1234");
@@ -323,7 +348,19 @@ public class ComScoreTest {
 
   @Test
   public void videoPlaybackBufferCompleted() {
-    setupWithVideoPlaybackStarted();
+    videoPlaybackBufferCompleted(false);
+  }
+
+  @Test
+  public void videoPlaybackBufferCompletedCamelCase() {
+    videoPlaybackBufferCompleted(true);
+  }
+
+  /*
+   * One test that verifies camel case and snake case are handled in properties.
+   */
+  private void videoPlaybackBufferCompleted(boolean useCamelCaseProperties) {
+    setupWithVideoPlaybackStarted(useCamelCaseProperties);
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Buffer Completed")
             .properties(new Properties().putValue("asset_id", 1029)


### PR DESCRIPTION
Our Android integration only looks for camel cased properties, however we advise customers to use snake casing too. We need to update our integration to handle snake cased properties especially since our ComScore iOS integration does (achieve parity). Related to https://segment.atlassian.net/browse/DEST-2088. Unit tests not yet performed.