### PR TITLE
STRATCONN-268 Test case that uses camel case to verify legacy behavior is supported

### DIFF
--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -190,6 +190,16 @@ public class ComScoreTest {
 
   @Test
   public void setupWithVideoPlaybackStarted() {
+    setupWithVideoPlaybackStarted(false);
+  }
+
+  @Test
+  public void setupWithVideoPlaybackStartedCamelCase() {
+    setupWithVideoPlaybackStarted(true);
+  }
+
+  @Test
+  public void setupWithVideoPlaybackStarted(boolean useCamelCaseProperties) {
     LinkedHashMap<String, String> expected = new LinkedHashMap<>();
     expected.put("ns_st_mp", "youtube");
     expected.put("ns_st_vo", "80");
@@ -199,17 +209,33 @@ public class ComScoreTest {
     expected.put("c4", "another value");
     expected.put("c6", "and another one");
 
-    integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
-            .properties(new Properties().putValue("asset_id", 1234)
-                    .putValue("ad_type", "pre-roll")
-                    .putValue("total_length", 120)
-                    .putValue("video_player", "youtube")
-                    .putValue("sound", 80)
-                    .putValue("full_screen", false)
-                    .putValue("c3", "some value")
-                    .putValue("c4", "another value")
-                    .putValue("c6", "and another one"))
-            .build());
+    // Both camel case and snake case properties should be supported.
+    if (useCamelCaseProperties) {
+      integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
+              .properties(new Properties().putValue("assetId", 1234)
+                      .putValue("adType", "pre-roll")
+                      .putValue("totalLength", 120)
+                      .putValue("videoPlayer", "youtube")
+                      .putValue("sound", 80)
+                      .putValue("fullScreen", false)
+                      .putValue("c3", "some value")
+                      .putValue("c4", "another value")
+                      .putValue("c6", "and another one"))
+              .build());
+    } else {
+      integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started")
+              .properties(new Properties().putValue("asset_id", 1234)
+                      .putValue("ad_type", "pre-roll")
+                      .putValue("total_length", 120)
+                      .putValue("video_player", "youtube")
+                      .putValue("sound", 80)
+                      .putValue("full_screen", false)
+                      .putValue("c3", "some value")
+                      .putValue("c4", "another value")
+                      .putValue("c6", "and another one"))
+              .build());
+    }
+
 
     Map<String, String> contentIdMapper = new LinkedHashMap<>();
     contentIdMapper.put("ns_st_ci", "1234");
@@ -323,7 +349,20 @@ public class ComScoreTest {
 
   @Test
   public void videoPlaybackBufferCompleted() {
-    setupWithVideoPlaybackStarted();
+    videoPlaybackBufferCompleted(false);
+  }
+
+  @Test
+  public void videoPlaybackBufferCompletedCamelCase() {
+    videoPlaybackBufferCompleted(true);
+  }
+
+  /*
+   * One test that verifies camel case and snake case are handled in properties.
+   */
+  @Test
+  public void videoPlaybackBufferCompleted(boolean camelCase) {
+    setupWithVideoPlaybackStarted(camelCase);
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Buffer Completed")
             .properties(new Properties().putValue("asset_id", 1029)

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -198,7 +198,7 @@ public class ComScoreTest {
     setupWithVideoPlaybackStarted(true);
   }
 
-  public void setupWithVideoPlaybackStarted(boolean useCamelCaseProperties) {
+  private void setupWithVideoPlaybackStarted(boolean useCamelCaseProperties) {
     LinkedHashMap<String, String> expected = new LinkedHashMap<>();
     expected.put("ns_st_mp", "youtube");
     expected.put("ns_st_vo", "80");
@@ -359,8 +359,8 @@ public class ComScoreTest {
   /*
    * One test that verifies camel case and snake case are handled in properties.
    */
-  public void videoPlaybackBufferCompleted(boolean camelCase) {
-    setupWithVideoPlaybackStarted(camelCase);
+  private void videoPlaybackBufferCompleted(boolean useCamelCaseProperties) {
+    setupWithVideoPlaybackStarted(useCamelCaseProperties);
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Playback Buffer Completed")
             .properties(new Properties().putValue("asset_id", 1029)

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -198,7 +198,6 @@ public class ComScoreTest {
     setupWithVideoPlaybackStarted(true);
   }
 
-  @Test
   public void setupWithVideoPlaybackStarted(boolean useCamelCaseProperties) {
     LinkedHashMap<String, String> expected = new LinkedHashMap<>();
     expected.put("ns_st_mp", "youtube");
@@ -360,7 +359,6 @@ public class ComScoreTest {
   /*
    * One test that verifies camel case and snake case are handled in properties.
    */
-  @Test
   public void videoPlaybackBufferCompleted(boolean camelCase) {
     setupWithVideoPlaybackStarted(camelCase);
 


### PR DESCRIPTION
Original PR (https://github.com/segment-integrations/analytics-android-integration-comscore/pull/15) modifies the existing test coverage for the new functionality that handles snake case. This PR adds back some of the original test coverage for handling camel case. Now, we should have test coverage for both snake and camel case.