### PR TITLE
Adding local configurationlabels dictionary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.comscore:android-analytics:6.5.1'
+  api 'com.comscore:android-analytics:6.5.+'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
   testImplementation 'org.robolectric:robolectric:4.3.1'
   testImplementation 'org.mockito:mockito-core:3.1.0'
 
+  //adding so Roboelectic can retrieve application context
+  testImplementation 'androidx.test:core:1.2.0'
+
   // Required for local (non-android) testing
   testImplementation 'org.json:json:20180813'
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.comscore:android-analytics:6.0.0'
+  api 'com.comscore:android-analytics:6.5.1'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ android {
   buildToolsVersion '28.0.3'
 
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion 28
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
   }
 
   api 'com.segment.analytics.android:analytics:4.3.1'
-  api 'com.comscore:android-analytics:6.5.+'
+  api 'com.comscore:android-analytics:6.5.0'
 
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreAnalytics.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreAnalytics.java
@@ -83,6 +83,7 @@ public interface ComScoreAnalytics {
             Analytics.getConfiguration().addClient(publisher);
 
             logger.verbose("Starting ComScore Analytics");
+
             Analytics.start(context);
         }
 

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreAnalytics.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreAnalytics.java
@@ -11,98 +11,103 @@ import com.segment.analytics.integrations.Logger;
 import java.util.Map;
 
 /**
- * This is a wrapper to all ComScore components. It helps with testing since
- * ComScore relays heavily on JNI and static classes, and all needs to be
- * mocked in any case.
+ * This is a wrapper to all ComScore components. It helps with testing since ComScore relays heavily
+ * on JNI and static classes, and all needs to be mocked in any case.
  */
 public interface ComScoreAnalytics {
 
-    /**
-     * Creates a new streaming analytics session.
-     * @return The new session.
-     */
-    public StreamingAnalytics createStreamingAnalytics();
+  /**
+   * Creates a new streaming analytics session.
+   *
+   * @return The new session.
+   */
+  public StreamingAnalytics createStreamingAnalytics();
 
-    /**
-     * Starts collecting analytics with the provided client configuration
-     * @param context Application context
-     * @param partnerId Partner ID
-     * @param publisher Publisher configuration
-     */
-    public void start(Context context, String partnerId, PublisherConfiguration publisher);
+  /**
+   * Starts collecting analytics with the provided client configuration
+   *
+   * @param context Application context
+   * @param partnerId Partner ID
+   * @param publisher Publisher configuration
+   */
+  public void start(Context context, String partnerId, PublisherConfiguration publisher);
 
-    /**
-     * Sets global labels
-     * @param labels Labels.
-     */
-    public void setPersistentLabels(Map<String, String> labels);
+  /**
+   * Sets global labels
+   *
+   * @param labels Labels.
+   */
+  public void setPersistentLabels(Map<String, String> labels);
 
-    /**
-     * Sends an view event with the provided properties.
-     * @param properties Event properties.
-     */
-    public void notifyViewEvent(Map<String, String> properties);
+  /**
+   * Sends an view event with the provided properties.
+   *
+   * @param properties Event properties.
+   */
+  public void notifyViewEvent(Map<String, String> properties);
 
-    /**
-     * Sends an unmapped event with the provided properties.
-     * @param properties Event properties.
-     */
-    public void notifyHiddenEvent(Map<String, String> properties);
+  /**
+   * Sends an unmapped event with the provided properties.
+   *
+   * @param properties Event properties.
+   */
+  public void notifyHiddenEvent(Map<String, String> properties);
 
-    /**
-     * Default implementation of ComScoreAnalytics. It uses the methods and classes
-     * provided by the ComScore SDK.
-     */
-    public class DefaultcomScoreAnalytics implements ComScoreAnalytics {
+  /**
+   * Default implementation of ComScoreAnalytics. It uses the methods and classes provided by the
+   * ComScore SDK.
+   */
+  public class DefaultcomScoreAnalytics implements ComScoreAnalytics {
 
-        private Logger logger;
+    private Logger logger;
 
-        public DefaultcomScoreAnalytics() {
-            logger = Logger.with(com.segment.analytics.Analytics.LogLevel.NONE);
-        }
-
-        public DefaultcomScoreAnalytics(Logger logger) {
-            this.logger = logger;
-        }
-
-        @Override
-        public StreamingAnalytics createStreamingAnalytics() {
-            logger.verbose("Creating streaming analytics");
-            return new StreamingAnalytics();
-        }
-
-        @Override
-        public void start(Context context, String partnerId, PublisherConfiguration publisher) {
-
-            PartnerConfiguration partner = new PartnerConfiguration.Builder().partnerId(partnerId).build();
-
-            logger.verbose("Adding partner (%s)", partner);
-            Analytics.getConfiguration().addClient(partner);
-
-            logger.verbose("Adding publisher (%s)", publisher);
-            Analytics.getConfiguration().addClient(publisher);
-
-            logger.verbose("Starting ComScore Analytics");
-
-            Analytics.start(context);
-        }
-
-        @Override
-        public void setPersistentLabels(Map<String, String> labels) {
-            logger.verbose("Analytics.getConfiguration().addPersistentLabels(%s)", labels);
-            Analytics.getConfiguration().addPersistentLabels(labels);
-        }
-
-        @Override
-        public void notifyViewEvent(Map<String, String> properties) {
-            logger.verbose("Analytics.notifyViewEvent(%s)", properties);
-            Analytics.notifyViewEvent(properties);
-        }
-
-        @Override
-        public void notifyHiddenEvent(Map<String, String> properties) {
-            logger.verbose("Analytics.notifyHiddenEvent(%s)", properties);
-            Analytics.notifyHiddenEvent(properties);
-        }
+    public DefaultcomScoreAnalytics() {
+      logger = Logger.with(com.segment.analytics.Analytics.LogLevel.NONE);
     }
+
+    public DefaultcomScoreAnalytics(Logger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    public StreamingAnalytics createStreamingAnalytics() {
+      logger.verbose("Creating streaming analytics");
+      return new StreamingAnalytics();
+    }
+
+    @Override
+    public void start(Context context, String partnerId, PublisherConfiguration publisher) {
+
+      PartnerConfiguration partner =
+          new PartnerConfiguration.Builder().partnerId(partnerId).build();
+
+      logger.verbose("Adding partner (%s)", partner);
+      Analytics.getConfiguration().addClient(partner);
+
+      logger.verbose("Adding publisher (%s)", publisher);
+      Analytics.getConfiguration().addClient(publisher);
+
+      logger.verbose("Starting ComScore Analytics");
+
+      Analytics.start(context);
+    }
+
+    @Override
+    public void setPersistentLabels(Map<String, String> labels) {
+      logger.verbose("Analytics.getConfiguration().addPersistentLabels(%s)", labels);
+      Analytics.getConfiguration().addPersistentLabels(labels);
+    }
+
+    @Override
+    public void notifyViewEvent(Map<String, String> properties) {
+      logger.verbose("Analytics.notifyViewEvent(%s)", properties);
+      Analytics.notifyViewEvent(properties);
+    }
+
+    @Override
+    public void notifyHiddenEvent(Map<String, String> properties) {
+      logger.verbose("Analytics.notifyHiddenEvent(%s)", properties);
+      Analytics.notifyHiddenEvent(properties);
+    }
+  }
 }

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -20,20 +20,20 @@ import java.util.Map;
 public class ComScoreIntegration extends Integration<Void> {
   @SuppressWarnings("WeakerAccess")
   public static final Factory FACTORY =
-          new Factory() {
-            @Override
-            public Integration<?> create(ValueMap settings, com.segment.analytics.Analytics analytics) {
-              return new ComScoreIntegration(analytics, settings);
-            }
+      new Factory() {
+        @Override
+        public Integration<?> create(ValueMap settings, com.segment.analytics.Analytics analytics) {
+          return new ComScoreIntegration(analytics, settings);
+        }
 
-            @Override
-            public String key() {
-              return COMSCORE_KEY;
-            }
-          };
+        @Override
+        public String key() {
+          return COMSCORE_KEY;
+        }
+      };
 
-  private final static String COMSCORE_KEY = "comScore";
-  private final static String PARTNER_ID = "24186693";
+  private static final String COMSCORE_KEY = "comScore";
+  private static final String PARTNER_ID = "24186693";
 
   //initalizing empty hashmap to store video labels. This replaces the methods
   //getConfiguration().getLabel and getConfiguration().containsLabel. Both methods were deprecated
@@ -45,21 +45,24 @@ public class ComScoreIntegration extends Integration<Void> {
   private StreamingAnalytics streamingAnalytics;
   private Logger logger;
 
-  ComScoreIntegration(com.segment.analytics.Analytics analytics,
-                      ValueMap destinationSettings) {
-    this(analytics, destinationSettings, new ComScoreAnalytics.DefaultcomScoreAnalytics(analytics.logger(COMSCORE_KEY)));
+  ComScoreIntegration(com.segment.analytics.Analytics analytics, ValueMap destinationSettings) {
+    this(
+        analytics,
+        destinationSettings,
+        new ComScoreAnalytics.DefaultcomScoreAnalytics(analytics.logger(COMSCORE_KEY)));
   }
 
   ComScoreIntegration(
-          com.segment.analytics.Analytics analytics,
-          ValueMap destinationSettings,
-          ComScoreAnalytics comScoreAnalytics) {
+      com.segment.analytics.Analytics analytics,
+      ValueMap destinationSettings,
+      ComScoreAnalytics comScoreAnalytics) {
 
     this.comScoreAnalytics = comScoreAnalytics;
     this.settings = new Settings(destinationSettings);
     this.logger = analytics.logger(COMSCORE_KEY);
 
-    comScoreAnalytics.start(analytics.getApplication(), PARTNER_ID, settings.toPublisherConfiguration());
+    comScoreAnalytics.start(
+        analytics.getApplication(), PARTNER_ID, settings.toPublisherConfiguration());
     settings.analyticsConfig();
   }
 
@@ -68,10 +71,10 @@ public class ComScoreIntegration extends Integration<Void> {
    * falling back to {@param properties}. Uses {@code "*null"} it not found in either.
    */
   private void setNullIfNotProvided(
-          Map<String, String> asset,
-          Map<String, ?> comScoreOptions,
-          Map<String, ?> stringProperties,
-          String key) {
+      Map<String, String> asset,
+      Map<String, ?> comScoreOptions,
+      Map<String, ?> stringProperties,
+      String key) {
     String option = getStringOrDefaultValue(comScoreOptions, key, null);
     if (option != null) {
       asset.put(key, option);
@@ -86,8 +89,7 @@ public class ComScoreIntegration extends Integration<Void> {
     asset.put(key, "*null");
   }
 
-  private Map<String, String> mapSpecialKeys(
-          Properties properties, Map<String, String> mapper) {
+  private Map<String, String> mapSpecialKeys(Properties properties, Map<String, String> mapper) {
     Map<String, String> asset = new LinkedHashMap<>(mapper.size());
 
     // Map special keys and preserve only the special keys.
@@ -104,15 +106,13 @@ public class ComScoreIntegration extends Integration<Void> {
   }
 
   private Map<String, String> mapPlaybackProperties(
-          Properties properties,
-          Map<String, ?> options,
-          Map<String, String> mapper) {
+      Properties properties, Map<String, ?> options, Map<String, String> mapper) {
 
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
     boolean fullScreen = properties.getBoolean("fullScreen", false);
     if (fullScreen == false) {
-      fullScreen =  properties.getBoolean("full_screen", false);
+      fullScreen = properties.getBoolean("full_screen", false);
     }
     asset.put("ns_st_ws", fullScreen ? "full" : "norm");
 
@@ -127,9 +127,7 @@ public class ComScoreIntegration extends Integration<Void> {
   }
 
   private Map<String, String> mapContentProperties(
-          Properties properties,
-          Map<String, ?> options,
-          Map<String, String> mapper) {
+      Properties properties, Map<String, ?> options, Map<String, String> mapper) {
 
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
@@ -175,9 +173,7 @@ public class ComScoreIntegration extends Integration<Void> {
   }
 
   private Map<String, String> mapAdProperties(
-          Properties properties,
-          Map<String, ?> options,
-          Map<String, String> mapper) {
+      Properties properties, Map<String, ?> options, Map<String, String> mapper) {
 
     Map<String, String> asset = mapSpecialKeys(properties, mapper);
 
@@ -220,8 +216,7 @@ public class ComScoreIntegration extends Integration<Void> {
    * <p>This will return {@code defaultValue} only if the value does not exist, since all types can
    * have a String representation.
    */
-  private String getStringOrDefaultValue(
-          Map<String, ?> m, String key, String defaultValue) {
+  private String getStringOrDefaultValue(Map<String, ?> m, String key, String defaultValue) {
     Object value = m.get(key);
     if (value instanceof String) {
       return (String) value;
@@ -234,7 +229,7 @@ public class ComScoreIntegration extends Integration<Void> {
   }
 
   private void trackVideoPlayback(
-          TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
+      TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
     if (playbackPosition == 0) {
@@ -243,13 +238,12 @@ public class ComScoreIntegration extends Integration<Void> {
     String adType = properties.getString("adType");
     if (adType == null || adType.trim().isEmpty()) {
       adType = properties.getString("ad_type");
-      if(adType == null){
+      if (adType == null || adType.trim().isEmpty()) {
         adType = properties.getString("type");
       }
     }
 
     configurationLabels.clear();
-
 
     Map<String, String> playbackMapper = new LinkedHashMap<>();
     playbackMapper.put("videoPlayer", "ns_st_mp");
@@ -257,7 +251,7 @@ public class ComScoreIntegration extends Integration<Void> {
     playbackMapper.put("sound", "ns_st_vo");
 
     Map<String, String> mappedPlaybackProperties =
-            mapPlaybackProperties(properties, comScoreOptions, playbackMapper);
+        mapPlaybackProperties(properties, comScoreOptions, playbackMapper);
 
     if (name.equals("Video Playback Started")) {
       streamingAnalytics = comScoreAnalytics.createStreamingAnalytics();
@@ -265,20 +259,17 @@ public class ComScoreIntegration extends Integration<Void> {
       streamingAnalytics.getConfiguration().addLabels(mappedPlaybackProperties);
 
       // adding ad_type to configurationLabels assuming pre-roll ad plays before video content
-      if(adType != null) {
+      if (adType != null) {
         configurationLabels.put("ns_st_ad", adType);
       }
-
 
       // The label ns_st_ci must be set through a setAsset call
       Map<String, String> contentIdMapper = new LinkedHashMap<>();
       contentIdMapper.put("assetId", "ns_st_ci");
       contentIdMapper.put("asset_id", "ns_st_ci");
 
-
       Map<String, String> mappedContentProperties = mapSpecialKeys(properties, contentIdMapper);
       streamingAnalytics.setMetadata(getContentMetadata(mappedContentProperties));
-
 
       configurationLabels.put("ns_st_ci", mappedContentProperties.get("ns_st_ci"));
 
@@ -287,7 +278,7 @@ public class ComScoreIntegration extends Integration<Void> {
 
     if (streamingAnalytics == null) {
       logger.verbose(
-              "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
+          "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
       return;
     }
     streamingAnalytics.getConfiguration().addLabels(mappedPlaybackProperties);
@@ -325,9 +316,8 @@ public class ComScoreIntegration extends Integration<Void> {
     }
   }
 
-
   private void trackVideoContent(
-          TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
+      TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
     if (playbackPosition == 0) {
@@ -348,11 +338,11 @@ public class ComScoreIntegration extends Integration<Void> {
     contentMapper.put("pod_id", "ns_st_pn");
 
     Map<String, String> mappedContentProperties =
-            mapContentProperties(properties, comScoreOptions, contentMapper);
+        mapContentProperties(properties, comScoreOptions, contentMapper);
 
     if (streamingAnalytics == null) {
       logger.verbose(
-              "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
+          "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
       return;
     }
 
@@ -370,7 +360,7 @@ public class ComScoreIntegration extends Integration<Void> {
         // we need to call setAsset with the content metadata.  If ns_st_ad is not present, that means the last
         // observed event was related to content, in which case a setAsset call should not be made (because asset
         // did not change).
-        if(configurationLabels.containsKey("ns_st_ad")){
+        if (configurationLabels.containsKey("ns_st_ad")) {
           streamingAnalytics.setMetadata(getContentMetadata(mappedContentProperties));
           logger.verbose("streamingAnalytics.setMetadata(%s)", mappedContentProperties);
         }
@@ -388,7 +378,7 @@ public class ComScoreIntegration extends Integration<Void> {
   }
 
   public void trackVideoAd(
-          TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
+      TrackPayload track, Properties properties, Map<String, Object> comScoreOptions) {
     String name = track.event();
     long playbackPosition = properties.getLong("playbackPosition", 0);
     if (playbackPosition == 0) {
@@ -397,7 +387,7 @@ public class ComScoreIntegration extends Integration<Void> {
     String adType = properties.getString("adType");
     if (adType == null || adType.trim().isEmpty()) {
       adType = properties.getString("ad_type");
-      if(adType == null){
+      if (adType == null || adType.trim().isEmpty()) {
         adType = properties.getString("type");
       }
     }
@@ -408,16 +398,15 @@ public class ComScoreIntegration extends Integration<Void> {
     adMapper.put("title", "ns_st_amt");
     adMapper.put("publisher", "ns_st_pu");
 
-    if (adType != null){
+    if (adType != null) {
       configurationLabels.put("ns_st_ad", adType);
     }
-
 
     Map<String, String> mappedAdProperties = mapAdProperties(properties, comScoreOptions, adMapper);
 
     if (streamingAnalytics == null) {
       logger.verbose(
-              "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
+          "streamingAnalytics instance not initialized correctly. Please call Video Playback Started to initialize.");
       return;
     }
 
@@ -428,7 +417,6 @@ public class ComScoreIntegration extends Integration<Void> {
         // calls (if this is a mid or post-roll), or on Video Playback Started (if this is a pre-roll).
 
         String contentId = configurationLabels.get("ns_st_ci");
-
 
         if (!isNullOrEmpty(contentId)) {
           mappedAdProperties.put("ns_st_ci", contentId);
@@ -453,16 +441,13 @@ public class ComScoreIntegration extends Integration<Void> {
         break;
     }
   }
-  private ContentMetadata getContentMetadata(Map<String, String> mappedContentProperties){
-    return new ContentMetadata.Builder()
-            .customLabels(mappedContentProperties)
-            .build();
+
+  private ContentMetadata getContentMetadata(Map<String, String> mappedContentProperties) {
+    return new ContentMetadata.Builder().customLabels(mappedContentProperties).build();
   }
 
-  private AdvertisementMetadata getAdvertisementMetadata(Map<String, String> mappedAdProperties){
-    return new AdvertisementMetadata.Builder()
-            .customLabels(mappedAdProperties)
-            .build();
+  private AdvertisementMetadata getAdvertisementMetadata(Map<String, String> mappedAdProperties) {
+    return new AdvertisementMetadata.Builder().customLabels(mappedAdProperties).build();
   }
 
   @Override
@@ -470,8 +455,7 @@ public class ComScoreIntegration extends Integration<Void> {
     String event = track.event();
     Properties properties = track.properties();
 
-    Map<String, Object> comScoreOptions = track
-            .integrations().getValueMap("comScore");
+    Map<String, Object> comScoreOptions = track.integrations().getValueMap("comScore");
     if (isNullOrEmpty(comScoreOptions)) {
       comScoreOptions = Collections.emptyMap();
     }
@@ -520,8 +504,8 @@ public class ComScoreIntegration extends Integration<Void> {
     String name = screen.name();
     String category = screen.category();
     HashMap<String, String> properties =
-            (HashMap<String, String>) //
-                    screen.properties().toStringMap();
+        (HashMap<String, String>) //
+            screen.properties().toStringMap();
     properties.put("name", name);
     properties.put("category", category);
     comScoreAnalytics.notifyViewEvent(properties);
@@ -529,6 +513,7 @@ public class ComScoreIntegration extends Integration<Void> {
 
   /**
    * Retrieves the settings.
+   *
    * @return Settings.
    */
   Settings getSettings() {

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/Settings.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/Settings.java
@@ -5,127 +5,136 @@ import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.segment.analytics.ValueMap;
 
-/**
- * Encapsulates all settings required to initialize the ComsCore destination.
- */
+/** Encapsulates all settings required to initialize the ComsCore destination. */
 public class Settings {
 
-    private final static int DEFAULT_INTERVAL = 60;
-    private final static boolean DEFAULT_HTTPS = true;
-    private final static boolean DEFAULT_AUTOUPDATE = false;
-    private final static boolean DEFAULT_FOREGROUND = true;
+  private static final int DEFAULT_INTERVAL = 60;
+  private static final boolean DEFAULT_HTTPS = true;
+  private static final boolean DEFAULT_AUTOUPDATE = false;
+  private static final boolean DEFAULT_FOREGROUND = true;
 
-    private String c2;
-    private String appName;
-    private String publisherSecret;
-    private boolean autoUpdate;
-    private int autoUpdateInterval;
-    private boolean useHTTPS;
-    private boolean foregroundOnly;
+  private String c2;
+  private String appName;
+  private String publisherSecret;
+  private boolean autoUpdate;
+  private int autoUpdateInterval;
+  private boolean useHTTPS;
+  private boolean foregroundOnly;
 
-    /**
-     * Creates the settings from the provided map.
-     * @param destinationSettings Destination settings
-     */
-    public Settings(ValueMap destinationSettings) {
-        this.c2 = destinationSettings.getString("c2");
-        this.publisherSecret = destinationSettings.getString("publisherSecret");
-        this.autoUpdateInterval = destinationSettings.getInt("autoUpdateInterval", DEFAULT_INTERVAL);
-        this.autoUpdate = destinationSettings.getBoolean("autoUpdate", DEFAULT_AUTOUPDATE);
-        this.foregroundOnly = destinationSettings.getBoolean("foregroundOnly", DEFAULT_FOREGROUND);
-        this.useHTTPS = destinationSettings.getBoolean("useHTTPS", DEFAULT_HTTPS);
-        this.appName = destinationSettings.getString("appName");
+  /**
+   * Creates the settings from the provided map.
+   *
+   * @param destinationSettings Destination settings
+   */
+  public Settings(ValueMap destinationSettings) {
+    this.c2 = destinationSettings.getString("c2");
+    this.publisherSecret = destinationSettings.getString("publisherSecret");
+    this.autoUpdateInterval = destinationSettings.getInt("autoUpdateInterval", DEFAULT_INTERVAL);
+    this.autoUpdate = destinationSettings.getBoolean("autoUpdate", DEFAULT_AUTOUPDATE);
+    this.foregroundOnly = destinationSettings.getBoolean("foregroundOnly", DEFAULT_FOREGROUND);
+    this.useHTTPS = destinationSettings.getBoolean("useHTTPS", DEFAULT_HTTPS);
+    this.appName = destinationSettings.getString("appName");
 
-        if (appName != null && appName.trim().length() == 0) {
-            // Application name as null
-            appName = null;
-        }
+    if (appName != null && appName.trim().length() == 0) {
+      // Application name as null
+      appName = null;
     }
+  }
 
-    /**
-     * Retrieves the customerId (a.k.a customerC2, publisherId, c2).
-     * @return Customer Id.
-     */
-    public String getCustomerId() {
-        return c2;
+  /**
+   * Retrieves the customerId (a.k.a customerC2, publisherId, c2).
+   *
+   * @return Customer Id.
+   */
+  public String getCustomerId() {
+    return c2;
+  }
+
+  /**
+   * Retrieves the application name for this instance.
+   *
+   * @return Application name.
+   */
+  public String getAppName() {
+    return appName;
+  }
+
+  /**
+   * Retrieves the publisher secret.
+   *
+   * @return Publisher secret.
+   */
+  public String getPublisherSecret() {
+    return publisherSecret;
+  }
+
+  /**
+   * Retrieves if the usage properties must autoupdate.
+   *
+   * @return <code>true</code> if the usage properties will auto-update. <code>false</code>
+   *     otherwise.
+   */
+  public boolean isAutoUpdate() {
+    return autoUpdate;
+  }
+
+  /**
+   * Retrieves the interval for auto-update.
+   *
+   * @return Interval in seconds.
+   */
+  public int getAutoUpdateInterval() {
+    return autoUpdateInterval;
+  }
+
+  /**
+   * Retrieves if the comscore install will use HTTPS.
+   *
+   * @return <code>true</code> if HTTPS is enabled. <code>false</code> otherwise.
+   */
+  public boolean isUseHTTPS() {
+    return useHTTPS;
+  }
+
+  /**
+   * Retrieves if usage tracking is enabled when the application is in foreground.
+   *
+   * @return <code>true</code> if foreground only tracking is enabled. <code>false</code> otherwise.
+   */
+  public boolean isForegroundOnly() {
+    return foregroundOnly;
+  }
+
+  /**
+   * Creates the publisher configuration with the specified settings.
+   *
+   * @return Publisher configuration for ComScore.
+   */
+  public PublisherConfiguration toPublisherConfiguration() {
+    PublisherConfiguration.Builder publisher = new PublisherConfiguration.Builder();
+    publisher.publisherId(c2);
+    publisher.secureTransmission(useHTTPS);
+    return publisher.build();
+  }
+
+  public void analyticsConfig() {
+    Analytics.getConfiguration().setUsagePropertiesAutoUpdateInterval(autoUpdateInterval);
+
+    if (appName != null) {
+      Analytics.getConfiguration().setApplicationName(appName);
     }
-
-    /**
-     * Retrieves the application name for this instance.
-     * @return Application name.
-     */
-    public String getAppName() {
-        return appName;
+    if (autoUpdate) {
+      Analytics.getConfiguration()
+          .setUsagePropertiesAutoUpdateMode(
+              UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
+    } else if (foregroundOnly) {
+      Analytics.getConfiguration()
+          .setUsagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
+    } else {
+      Analytics.getConfiguration()
+          .setUsagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
+      Analytics.getConfiguration()
+          .setUsagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.DISABLED);
     }
-
-    /**
-     * Retrieves the publisher secret.
-     * @return Publisher secret.
-     */
-    public String getPublisherSecret() {
-        return publisherSecret;
-    }
-
-    /**
-     * Retrieves if the usage properties must autoupdate.
-     * @return <code>true</code> if the usage properties will auto-update. <code>false</code> otherwise.
-     */
-    public boolean isAutoUpdate() {
-        return autoUpdate;
-    }
-
-    /**
-     * Retrieves the interval for auto-update.
-     * @return Interval in seconds.
-     */
-    public int getAutoUpdateInterval() {
-        return autoUpdateInterval;
-    }
-
-    /**
-     * Retrieves if the comscore install will use HTTPS.
-     * @return <code>true</code> if HTTPS is enabled. <code>false</code> otherwise.
-     */
-    public boolean isUseHTTPS() {
-        return useHTTPS;
-    }
-
-    /**
-     * Retrieves if usage tracking is enabled when the application is in foreground.
-     * @return <code>true</code> if foreground only tracking is enabled. <code>false</code> otherwise.
-     */
-    public boolean isForegroundOnly() {
-        return foregroundOnly;
-    }
-
-    /**
-     * Creates the publisher configuration with the specified settings.
-     * @return Publisher configuration for ComScore.
-     */
-    public PublisherConfiguration toPublisherConfiguration() {
-        PublisherConfiguration.Builder publisher = new PublisherConfiguration.Builder();
-        publisher.publisherId(c2);
-        publisher.secureTransmission(useHTTPS);
-        return publisher.build();
-    }
-
-    public void analyticsConfig(){
-        Analytics.getConfiguration().setUsagePropertiesAutoUpdateInterval(autoUpdateInterval);
-
-        if (appName != null) {
-            Analytics.getConfiguration().setApplicationName(appName);
-        }
-        if (autoUpdate) {
-            Analytics.getConfiguration().setUsagePropertiesAutoUpdateMode(
-                    UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND);
-        } else if (foregroundOnly) {
-            Analytics.getConfiguration().setUsagePropertiesAutoUpdateMode(
-                    UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY);
-        } else {
-            Analytics.getConfiguration().setUsagePropertiesAutoUpdateMode(
-                    UsagePropertiesAutoUpdateMode.DISABLED);
-            Analytics.getConfiguration().setUsagePropertiesAutoUpdateMode(
-                    UsagePropertiesAutoUpdateMode.DISABLED);
-        }
-    }
+  }
 }

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -25,6 +25,7 @@ import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -603,7 +604,7 @@ public class ComScoreTest {
   @Test
   public void videoContentPlaying() {
     setupWithVideoPlaybackStarted();
-    //Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
+    assertTrue(integration.configurationLabels.containsKey("ns_st_ad") && integration.configurationLabels.get("ns_st_ad") != null);
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
             .properties(new Properties().putValue("assetId", 123214)
@@ -633,10 +634,9 @@ public class ComScoreTest {
   @Test
   public void videoContentPlayingWithAdType() {
     setupWithVideoPlaybackStarted();
+    assertTrue(integration.configurationLabels.containsKey("ns_st_ad") && integration.configurationLabels.get("ns_st_ad") != null);
 
-    //Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
-
-     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
+    integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
              .properties(new Properties().putValue("assetId", 123214)
                      .putValue("title", "Look Who's Purging Now")
                      .putValue("season", 2)
@@ -697,7 +697,7 @@ public class ComScoreTest {
   @Test
   public void videoAdStarted() {
     setupWithVideoPlaybackStarted();
-
+    assertTrue(integration.configurationLabels.containsKey("ns_st_ad") && integration.configurationLabels.get("ns_st_ad") != null);
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started")
             .properties(new Properties().putValue("asset_id", 4311)
                     .putValue("pod_id", "adSegmentA")
@@ -794,17 +794,18 @@ public class ComScoreTest {
   @Test
   public void videoAdPlaying() {
     setupWithVideoPlaybackStarted();
-
+    assertTrue(integration.configurationLabels.containsKey("ns_st_ad") && integration.configurationLabels.get("ns_st_ad") != null);
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Ad Playing")
             .properties(new Properties().putValue("assetId", 4311)
                     .putValue("podId", "adSegmentA")
-                    .putValue("type", "pre-roll")
+                    .putValue("adType", "pre-roll")
                     .putValue("totalLength", 120)
                     .putValue("playbackPosition", 20)
                     .putValue("title", "Helmet Ad"))
             .build());
     streamingAnalytics.startFromPosition(20);
     Mockito.verify(streamingAnalytics).notifyPlay();
+
   }
 
   @Test

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.when;
 import android.app.Application;
+import android.content.pm.ApplicationInfo;
+
 import com.comscore.PublisherConfiguration;
 import com.comscore.streaming.AdvertisementMetadata;
 import com.comscore.streaming.ContentMetadata;
@@ -57,6 +59,8 @@ public class ComScoreTest {
   StreamingConfiguration streamingConfiguration;
 
 
+
+
   @Mock
   ComScoreIntegration integration;
 
@@ -82,7 +86,12 @@ public class ComScoreTest {
     ValueMap destinationSettings = new ValueMap();
     destinationSettings.putValue("c2", "foobarbar");
     destinationSettings.putValue("publisherSecret", "illnevertell");
+    when(context.getPackageName()).thenReturn("Code is running");
+    when(context.getApplicationContext()).thenReturn(context);
 
+    ApplicationInfo testApplicationInfo = Mockito.mock(ApplicationInfo.class);
+
+    when(context.getApplicationInfo()).thenReturn(testApplicationInfo);
     integration = (ComScoreIntegration) ComScoreIntegration.FACTORY.create(destinationSettings, analytics);
 
     Settings settings = integration.getSettings();

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -18,6 +18,7 @@ import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.IdentifyPayload;
+import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
@@ -33,19 +34,33 @@ import org.mockito.Mockito;
 
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
+
+//specifying earlier android SDK so Robolectric doesn't ask for Java 9
+@Config(sdk = 28)
+
 public class ComScoreTest {
 
   private final static String EXPECTED_PARTNER_ID = "24186693";
 
-  @Mock Application context;
-  @Mock ComScoreAnalytics comScoreAnalytics;
-  @Mock com.segment.analytics.Analytics analytics;
-  @Mock StreamingAnalytics streamingAnalytics;
-  @Mock StreamingConfiguration streamingConfiguration;
+  @Mock
+  Application context;
+  @Mock
+  ComScoreAnalytics comScoreAnalytics;
+  @Mock
+  com.segment.analytics.Analytics analytics;
+  @Mock
+  StreamingAnalytics streamingAnalytics;
+  @Mock
+  StreamingConfiguration streamingConfiguration;
 
-  private ComScoreIntegration integration;
+
+  @Mock
+  ComScoreIntegration integration;
+
+  //
 
   @Before
   public void setUp() {
@@ -131,7 +146,7 @@ public class ComScoreTest {
     Settings integrationSettings = integration.getSettings();
     assertEquals("testApp", integrationSettings.getAppName());
     assertEquals(2000, integrationSettings.getAutoUpdateInterval());
-    assertTrue( integrationSettings.isForegroundOnly());
+    assertTrue(integrationSettings.isForegroundOnly());
   }
 
   @Test
@@ -271,7 +286,7 @@ public class ComScoreTest {
     expected.put("c6", "*null");
 
     Mockito.verify(streamingAnalytics).createPlaybackSession();
-    Mockito.verify(streamingAnalytics,atLeast(1))
+    Mockito.verify(streamingAnalytics, atLeast(1))
             .setMetadata(refEq(getContentMetadata(contentIdMapper)));
     Mockito.verify(streamingAnalytics.getConfiguration()).addLabels(expected);
   }
@@ -514,7 +529,7 @@ public class ComScoreTest {
 
     Mockito.verify(streamingAnalytics).startFromPosition(70);
     Mockito.verify(streamingAnalytics).notifyPlay();
-    Mockito.verify(streamingAnalytics,atLeast(1))
+    Mockito.verify(streamingAnalytics, atLeast(1))
             .setMetadata(refEq(getContentMetadata(expected)));
   }
 
@@ -561,7 +576,7 @@ public class ComScoreTest {
 
     Mockito.verify(streamingAnalytics).startFromPosition(70);
     Mockito.verify(streamingAnalytics).notifyPlay();
-    Mockito.verify(streamingAnalytics,atLeast(1))
+    Mockito.verify(streamingAnalytics, atLeast(1))
             .setMetadata(refEq(getContentMetadata(expected)));
   }
 
@@ -577,7 +592,8 @@ public class ComScoreTest {
   @Test
   public void videoContentPlaying() {
     setupWithVideoPlaybackStarted();
-    Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
+    //Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
+
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
             .properties(new Properties().putValue("assetId", 123214)
                     .putValue("title", "Look Who's Purging Now")
@@ -593,28 +609,36 @@ public class ComScoreTest {
                     .putValue("playbackPosition", 70))
             .build());
 
-    Mockito.verify(streamingAnalytics).startFromPosition(70);
-    Mockito.verify(streamingAnalytics).notifyPlay();
-  }
+
+    Mockito.verify(streamingAnalytics).
+
+  startFromPosition(70);
+    Mockito.verify(streamingAnalytics).
+
+  notifyPlay();
+
+}
 
   @Test
   public void videoContentPlayingWithAdType() {
     setupWithVideoPlaybackStarted();
 
-    Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
-    integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
-            .properties(new Properties().putValue("assetId", 123214)
-                    .putValue("title", "Look Who's Purging Now")
-                    .putValue("season", 2)
-                    .putValue("episode", 9)
-                    .putValue("genre", "cartoon")
-                    .putValue("program", "Rick and Morty")
-                    .putValue("channel", "cartoon network")
-                    .putValue("publisher", "Turner Broadcasting System")
-                    .putValue("fullEpisode", true)
-                    .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70))
-            .build());
+    //Mockito.when(streamingAnalytics.getConfiguration().containsLabel("ns_st_ad")).thenReturn(true);
+
+     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
+             .properties(new Properties().putValue("assetId", 123214)
+                     .putValue("title", "Look Who's Purging Now")
+                     .putValue("season", 2)
+                     .putValue("episode", 9)
+                     .putValue("genre", "cartoon")
+                     .putValue("program", "Rick and Morty")
+                     .putValue("channel", "cartoon network")
+                     .putValue("publisher", "Turner Broadcasting System")
+                     .putValue("fullEpisode", true)
+                     .putValue("podId", "segment A")
+                     .putValue("playbackPosition", 70))
+             .build());
+
 
 
     LinkedHashMap<String, String> expected = new LinkedHashMap<>();

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -58,13 +59,9 @@ public class ComScoreTest {
   @Mock
   StreamingConfiguration streamingConfiguration;
 
-
-
-
   @Mock
   ComScoreIntegration integration;
 
-  //
 
   @Before
   public void setUp() {
@@ -87,7 +84,9 @@ public class ComScoreTest {
     destinationSettings.putValue("c2", "foobarbar");
     destinationSettings.putValue("publisherSecret", "illnevertell");
     when(context.getPackageName()).thenReturn("Code is running");
-    when(context.getApplicationContext()).thenReturn(context);
+
+    //updating Context mock to return roboelectric's RunTimeEnvironment object
+    when(context.getApplicationContext()).thenReturn(RuntimeEnvironment.application.getApplicationContext());
 
     ApplicationInfo testApplicationInfo = Mockito.mock(ApplicationInfo.class);
 
@@ -117,6 +116,9 @@ public class ComScoreTest {
     destinationSettings.putValue("foregroundOnly", false);
     destinationSettings.putValue("autoUpdate", true);
     destinationSettings.putValue("autoUpdateInterval", 12345);
+
+    //updating Context mock to return roboelectric's RunTimeEnvironment object
+    when(context.getApplicationContext()).thenReturn(RuntimeEnvironment.application.getApplicationContext());
 
     integration = (ComScoreIntegration) ComScoreIntegration.FACTORY.create(destinationSettings, analytics);
 

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -621,13 +621,10 @@ public class ComScoreTest {
                     .putValue("playbackPosition", 70))
             .build());
 
-
     Mockito.verify(streamingAnalytics).
 
-  startFromPosition(70);
-    Mockito.verify(streamingAnalytics).
-
-  notifyPlay();
+    startFromPosition(70);
+    Mockito.verify(streamingAnalytics).notifyPlay();
 
 }
 


### PR DESCRIPTION
[Jira ticket](https://segment.atlassian.net/browse/DEST-2225)
[stratconn ticket](https://segment.atlassian.net/browse/STRATCONN-489)
[iOS library PR](https://github.com/segment-integrations/analytics-ios-integration-comscore/pull/24)

For my fix, I added a local dictionary to store both assetId and adType. AssetId is added to dictionary when a video playback event is triggered. 

I am adding adType when when a video ad started event or video playback event fires (the latter in case a pre-roll ad doesn't fire a video ad started event). 