### PR TITLE
Update CI cacheing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
             - /home/circleci/.android
             - /home/circleci/android
             - /home/circleci/.gradle
-            - /usr/local/android-sdk-linux/platforms/android-25
-            - /usr/local/android-sdk-linux/build-tools/25.0.0
+            - /usr/local/android-sdk-linux/platforms/android-28
+            - /usr/local/android-sdk-linux/build-tools/28.0.3
             - /usr/local/android-sdk-linux/extras/android/m2repository
       - store_artifacts:
           path: analytics-core/build/test-report


### PR DESCRIPTION
- Looks as if we were cacheing an old version of the Android API and Android build tools. Hopefully merging this PR pushing tags again should fix the CI cacheing issues. We should be able to delete tag 4.2.0, then re-create it to kick off the `publish` step in CI.