### PR TITLE
fix incorrect logs.md

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -306,7 +306,7 @@ public class ComScoreIntegration extends Integration<Void> {
       case "Video Playback Seek Completed":
         streamingAnalytics.startFromPosition(playbackPosition);
         streamingAnalytics.notifyPlay();
-        logger.verbose("streamingAnalytics.notifyEnd(%s)", playbackPosition);
+        logger.verbose("streamingAnalytics.notifyPlay(%s)", playbackPosition);
         break;
       case "Video Playback Resumed":
         streamingAnalytics.startFromPosition(playbackPosition);
@@ -367,7 +367,7 @@ public class ComScoreIntegration extends Integration<Void> {
 
         streamingAnalytics.startFromPosition(playbackPosition);
         streamingAnalytics.notifyPlay();
-        logger.verbose("streamingAnalytics.notifyEnd(%s)", playbackPosition);
+        logger.verbose("streamingAnalytics.notifyPlay(%s)", playbackPosition);
         break;
 
       case "Video Content Completed":


### PR DESCRIPTION
Some logs said "notifyEnd" even though the actual method called is "notifyPlay". The actual method is correct in these cases, but the log was incorrect. Assuming this was a copy-and-paste error. I cleaned this up so our logs are indicative of true behavior. No changes made to actual code.