### PR TITLE
Comscore consent flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,23 +50,10 @@ android {
   }
 }
 
-allprojects {
-  repositories {
-    maven {
-      url "https://comscore.bintray.com/Analytics"
-    }
-  }
-}
 
-allprojects {
-  repositories {
-    maven {
-      url "https://comscore.bintray.com/Analytics"
-    }
-  }
-}
 
 dependencies {
+
   repositories {
     mavenCentral()
     jcenter()
@@ -81,6 +68,9 @@ dependencies {
   testImplementation 'com.android.support.test:runner:1.0.2'
   testImplementation 'org.robolectric:robolectric:4.3.1'
   testImplementation 'org.mockito:mockito-core:3.1.0'
+  testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.2"
+
+
 
   //adding so Roboelectic can retrieve application context
   testImplementation 'androidx.test:core:1.2.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ POM_DEVELOPER_ID=segmentio
 POM_DEVELOPER_NAME=Segment, Inc.
 
 android.enableUnitTestBinaryResources=true
+

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java
@@ -454,6 +454,8 @@ public class ComScoreIntegration extends Integration<Void> {
   private AdvertisementMetadata getAdvertisementMetadata(Map<String, String> mappedAdProperties) {
     return new AdvertisementMetadata.Builder().customLabels(mappedAdProperties).build();
   }
+  // A pattern to parse consent flag value
+  Pattern privacyStringPattern = Pattern.compile("^1(-|Y|N){3}");
 
   public HashMap<String, String> setConsentLabelValue(Map<String, String> main, Map<String, String> fallback, Settings settings) {
     if (settings.getConsentFlagProp() != null && !settings.getConsentFlagProp().trim().isEmpty() ) {
@@ -469,10 +471,8 @@ public class ComScoreIntegration extends Integration<Void> {
 
       if (consentFlagValue != null)
       {
-        // Parse consent flag value
-        Pattern privacyStringPattern = Pattern.compile("^1(-|Y|N){3}");
         Matcher privacyStringMatcher = privacyStringPattern.matcher(consentFlagValue);
-        // If consent value is a US Privacy String and the 3rd character is not "-"
+        // If consent value is not a US Privacy String with the 3rd character = "-"
         if (!(privacyStringMatcher.matches() && String.valueOf(consentFlagValue.toCharArray()[2]) == "-"))
         {
           if (consentFlagValue.equals("1") || consentFlagValue.equals("true")  ||

--- a/src/main/java/com/segment/analytics/android/integrations/comscore/Settings.java
+++ b/src/main/java/com/segment/analytics/android/integrations/comscore/Settings.java
@@ -5,6 +5,8 @@ import com.comscore.PublisherConfiguration;
 import com.comscore.UsagePropertiesAutoUpdateMode;
 import com.segment.analytics.ValueMap;
 
+import java.util.HashMap;
+
 /** Encapsulates all settings required to initialize the ComsCore destination. */
 public class Settings {
 
@@ -20,6 +22,7 @@ public class Settings {
   private int autoUpdateInterval;
   private boolean useHTTPS;
   private boolean foregroundOnly;
+  private String consentFlagProp; // Consent Flag change
 
   /**
    * Creates the settings from the provided map.
@@ -34,6 +37,8 @@ public class Settings {
     this.foregroundOnly = destinationSettings.getBoolean("foregroundOnly", DEFAULT_FOREGROUND);
     this.useHTTPS = destinationSettings.getBoolean("useHTTPS", DEFAULT_HTTPS);
     this.appName = destinationSettings.getString("appName");
+    this.consentFlagProp = destinationSettings.getString("consentFlag"); // Consent Flag change
+
 
     if (appName != null && appName.trim().length() == 0) {
       // Application name as null
@@ -106,6 +111,20 @@ public class Settings {
   }
 
   /**
+   * Retrieves mapped consent flag property
+   *
+   * @return <code>string</code> mapped property name.
+   */
+  public String getConsentFlagProp() {
+    return consentFlagProp;
+  }
+
+  public HashMap<String,String> setConsentFlag() {
+    HashMap<String, String> consentFlag = new HashMap<String,String>();
+    consentFlag.put("cs_ucfr", "" );
+    return consentFlag;
+  }
+  /**
    * Creates the publisher configuration with the specified settings.
    *
    * @return Publisher configuration for ComScore.
@@ -114,6 +133,7 @@ public class Settings {
     PublisherConfiguration.Builder publisher = new PublisherConfiguration.Builder();
     publisher.publisherId(c2);
     publisher.secureTransmission(useHTTPS);
+    publisher.persistentLabels(setConsentFlag());
     return publisher.build();
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -9,6 +9,7 @@ import com.comscore.streaming.ContentMetadata;
 import com.comscore.streaming.StreamingAnalytics;
 import com.comscore.streaming.StreamingConfiguration;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
@@ -18,10 +19,7 @@ import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -34,6 +32,8 @@ import org.robolectric.annotation.Config;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.segment.analytics.Utils.createContext;
+import static com.segment.analytics.Utils.createTraits;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -80,49 +80,7 @@ public class ComScoreTest {
     when(streamingAnalytics.getConfiguration()).thenReturn(streamingConfiguration);
     integration = new ComScoreIntegration(analytics, settings, comScoreAnalytics);
   }
-  // ----
-  @Nested
-  @DisplayName("consent flag")
-    public class testConsentFlag {
-    @BeforeClass
-    public void init() {
-      MockitoAnnotations.initMocks(this);
-      when(comScoreAnalytics.createStreamingAnalytics()).thenReturn(streamingAnalytics);
 
-      ValueMap settings = new ValueMap();
-      settings.putValue("customerC2", "foobarbar");
-      settings.putValue("publisherSecret", "illnevertell");
-      settings.putValue("consentFlag", "consentFlagProp");
-
-      when(analytics.logger("comScore")).thenReturn(Logger.with(Analytics.LogLevel.VERBOSE));
-      when(analytics.getApplication()).thenReturn(context);
-      when(streamingAnalytics.getConfiguration()).thenReturn(streamingConfiguration);
-      integration = new ComScoreIntegration(analytics, settings, comScoreAnalytics);
-    }
-    @Test
-    public void trackWithConsentFlagInteger() {
-      integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
-              .event("Test Event")
-              .properties(new Properties().putValue("consentFlagProp", "1").putValue("fruit", "banana"))
-              .build());
-
-      LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
-      expectedProps.put("fruit", "banana");
-      expectedProps.put("name", "Test Event");
-      expectedProps.put("consentFlagProp", "1");
-      LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
-      expectedFlag.put("cs_ucfr", "1");
-
-      Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
-      Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
-      Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
-    }
-
-  }
-
-
-
-  // ----
   @Test
   public void initialize() {
     ValueMap destinationSettings = new ValueMap();
@@ -217,7 +175,6 @@ public class ComScoreTest {
     settings.putValue("autoUpdate", false);
     settings.putValue("foregroundOnly", false);
 
-
     integration = new ComScoreIntegration(analytics, settings, comScoreAnalytics);
 
     Mockito.reset(comScoreAnalytics);
@@ -234,41 +191,6 @@ public class ComScoreTest {
     assertEquals("testApp", integrationSettings.getAppName());
     assertEquals(60, integrationSettings.getAutoUpdateInterval());
 //    assertEquals(UsagePropertiesAutoUpdateMode.DISABLED, publisher.getUsagePropertiesAutoUpdateMode());
-  }
-// Original
-//  @Test
-//  public void track() {
-//    integration.track(new TrackPayload.Builder().anonymousId("foo").event("foo").build());
-//    Properties properties = new Properties();
-//
-//    properties.putValue("name", "foo");
-//    properties.putValue("consentFlag", "1");
-//    Map<String, String> expected = properties.toStringMap();
-//    LinkedHashMap<String, String> label = new LinkedHashMap<>();
-//    label.put("cs_ucfr", "1");
-//
-//    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expected);
-//    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(label);
-//  }
-
-
-  @Test
-  public void trackWithNullConsentFlag() {
-    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
-            .event("Test Event")
-            .properties(new Properties().putValue("consentFlagProp", true).putValue("prop1", "foo"))
-            .build());
-
-    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
-    expectedProps.put("prop1", "foo");
-    expectedProps.put("name", "Test Event");
-    expectedProps.put("consentFlagProp", "true");
-    //LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
-    // expectedFlag.put("cs_ucfr", "1");
-
-    //Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
-    //Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
-    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
   }
 
   @Test
@@ -300,7 +222,14 @@ public class ComScoreTest {
     assertFalse(settings.isForegroundOnly());
   }
 
+  @Test
+  public void track() {
+    integration.track(new TrackPayload.Builder().anonymousId("foo").event("foo").build());
+    Properties properties = new Properties().putValue("name", "foo");
+    Map<String, String> expected = properties.toStringMap();
 
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expected);
+  }
 
   @Test
   public void trackWithProps() {
@@ -725,10 +654,10 @@ public class ComScoreTest {
 
     Mockito.verify(streamingAnalytics).
 
-    startFromPosition(70);
+            startFromPosition(70);
     Mockito.verify(streamingAnalytics).notifyPlay();
 
-}
+  }
 
   @Test
   public void videoContentPlayingWithAdType() {
@@ -736,18 +665,18 @@ public class ComScoreTest {
     assertTrue(integration.configurationLabels.containsKey("ns_st_ad") && integration.configurationLabels.get("ns_st_ad") != null);
 
     integration.track(new TrackPayload.Builder().anonymousId("foo").event("Video Content Playing")
-             .properties(new Properties().putValue("assetId", 123214)
-                     .putValue("title", "Look Who's Purging Now")
-                     .putValue("season", 2)
-                     .putValue("episode", 9)
-                     .putValue("genre", "cartoon")
-                     .putValue("program", "Rick and Morty")
-                     .putValue("channel", "cartoon network")
-                     .putValue("publisher", "Turner Broadcasting System")
-                     .putValue("fullEpisode", true)
-                     .putValue("podId", "segment A")
-                     .putValue("playbackPosition", 70))
-             .build());
+            .properties(new Properties().putValue("assetId", 123214)
+                    .putValue("title", "Look Who's Purging Now")
+                    .putValue("season", 2)
+                    .putValue("episode", 9)
+                    .putValue("genre", "cartoon")
+                    .putValue("program", "Rick and Morty")
+                    .putValue("channel", "cartoon network")
+                    .putValue("publisher", "Turner Broadcasting System")
+                    .putValue("fullEpisode", true)
+                    .putValue("podId", "segment A")
+                    .putValue("playbackPosition", 70))
+            .build());
 
 
 
@@ -954,6 +883,559 @@ public class ComScoreTest {
     Mockito.verify(comScoreAnalytics, Mockito.times(1))
             .notifyViewEvent(expected);
   }
+
+
+  @Test
+  public void trackWithConsentFlagPropBoolTrue() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp", true).putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "true");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropStringTrue() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp", "true").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "true");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropIntOne() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp", 1).putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "1");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropStringOne() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp", "1").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "1");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropBoolFalse() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp",false).putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "false");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+
+  }
+
+  @Test
+  public void trackWithConsentFlagPropStringFalse() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","false").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "false");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+
+  }
+
+  @Test
+  public void trackWithConsentFlagPropIntZero() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp",0).putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "0");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+
+  }
+
+
+  @Test
+  public void trackWithConsentFlagPropStringZero() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","0").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "0");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropUsPrivacyStringN() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","1YNY").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "1YNY");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropUsPrivacyStringY() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","1YYY").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "1YYY");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropUsPrivacyStringDash() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","1Y-Y").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "1Y-Y");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropValueNull() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp",null).putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "null");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropAdhocVal() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("consentFlagProp","somevalue").putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+    expectedProps.put("consentFlagProp", "somevalue");
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagPropMissing() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("prop1", "foo"))
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagContextStringOne() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    Traits traits = createTraits("bar").putValue("consentFlagProp", "1");
+    AnalyticsContext analyticsContext = createContext(traits);
+
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("prop1", "foo"))
+            .context(analyticsContext)
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagContextUsPrivacyStringDash() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    Traits traits = createTraits("bar").putValue("consentFlagProp", "1---");
+    AnalyticsContext analyticsContext = createContext(traits);
+
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("prop1", "foo"))
+            .context(analyticsContext)
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagContextIntZero() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    Traits traits = createTraits("bar").putValue("consentFlagProp", 0);
+    AnalyticsContext analyticsContext = createContext(traits);
+
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .properties(new Properties().putValue("prop1", "foo"))
+            .context(analyticsContext)
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("prop1", "foo");
+    expectedProps.put("name", "Test Event");
+
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "0");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void trackWithConsentFlagNull() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo anon id") //
+            .event("Test Event")
+            .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("name", "Test Event");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedProps);
+  }
+
+  @Test
+  public void identifyConsentFlagStringOne() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagTrait");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    Traits traits = new Traits();
+    traits.putValue("firstName", "Kylo");
+    traits.putValue("lastName", "Ren");
+    traits.putValue("consentFlagTrait", "1");
+
+    integration.identify(new IdentifyPayload.Builder().userId("foo")
+            .anonymousId("foobar").traits(traits).build());
+
+    LinkedHashMap<String, String> expected = new LinkedHashMap<>();
+    expected.put("anonymousId", "foobar");
+    expected.put("firstName", "Kylo");
+    expected.put("lastName", "Ren");
+    expected.put("userId", "foo");
+    expected.put("consentFlagTrait", "1");
+    expected.put("cs_ucfr", "1");
+
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expected);
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+  }
+
+  @Test
+  public void screenConsentFlagPropStringOne() {
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.screen(
+            new ScreenPayload.Builder()
+                    .anonymousId("foo")
+                    .name("SmartWatches")
+                    .category("Purchase Screen")
+                    .properties(new Properties().putValue("consentFlagProp","1"))
+                    .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("name", "SmartWatches");
+    expectedProps.put("category", "Purchase Screen");
+    expectedProps.put("consentFlagProp", "1");
+
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyViewEvent(expectedProps);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+  }
+
+  @Test
+  public void screenConsentFlagContextStringOne() {
+
+    ValueMap destinationSettings = new ValueMap();
+    destinationSettings.putValue("c2", "foobarbar");
+    destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlagProp");
+
+    Traits traits = createTraits("bar").putValue("consentFlagProp", "1");
+    AnalyticsContext analyticsContext = createContext(traits);
+
+    integration = new ComScoreIntegration(analytics, destinationSettings, comScoreAnalytics);
+
+    integration.screen(
+            new ScreenPayload.Builder()
+                    .anonymousId("foo")
+                    .name("SmartWatches")
+                    .category("Purchase Screen")
+                    .context(analyticsContext)
+                    .build());
+
+    LinkedHashMap<String, String> expectedProps = new LinkedHashMap<>();
+    expectedProps.put("name", "SmartWatches");
+    expectedProps.put("category", "Purchase Screen");
+
+    LinkedHashMap<String, String> expectedFlag = new LinkedHashMap<>();
+    expectedFlag.put("cs_ucfr", "1");
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyViewEvent(expectedProps);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).setPersistentLabels(expectedFlag);
+    Mockito.verify(comScoreAnalytics, Mockito.times(1)).notifyHiddenEvent(expectedFlag);
+  }
+
   private ContentMetadata getContentMetadata(Map<String, String> asset){
     return new ContentMetadata.Builder()
             .customLabels(asset)
@@ -964,9 +1446,4 @@ public class ComScoreTest {
             .customLabels(adAsset)
             .build();
   }
-
-
-
 }
-
-

--- a/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/comscore/ComScoreTest.java
@@ -1,12 +1,5 @@
 package com.segment.analytics.android.integrations.comscore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.refEq;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.content.pm.ApplicationInfo;
 
@@ -20,25 +13,31 @@ import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.IdentifyPayload;
-import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 
@@ -72,6 +71,7 @@ public class ComScoreTest {
     ValueMap settings = new ValueMap();
     settings.putValue("customerC2", "foobarbar");
     settings.putValue("publisherSecret", "illnevertell");
+    settings.putValue("consentFlag", "consentFlag");
 
     when(analytics.logger("comScore")).thenReturn(Logger.with(Analytics.LogLevel.VERBOSE));
     when(analytics.getApplication()).thenReturn(context);
@@ -84,6 +84,7 @@ public class ComScoreTest {
     ValueMap destinationSettings = new ValueMap();
     destinationSettings.putValue("c2", "foobarbar");
     destinationSettings.putValue("publisherSecret", "illnevertell");
+    destinationSettings.putValue("consentFlag", "consentFlag");
     when(context.getPackageName()).thenReturn("Code is running");
 
     //updating Context mock to return roboelectric's RunTimeEnvironment object
@@ -117,6 +118,7 @@ public class ComScoreTest {
     destinationSettings.putValue("foregroundOnly", false);
     destinationSettings.putValue("autoUpdate", true);
     destinationSettings.putValue("autoUpdateInterval", 12345);
+    destinationSettings.putValue("consentFlag", "consentFlag");
 
     //updating Context mock to return roboelectric's RunTimeEnvironment object
     when(context.getApplicationContext()).thenReturn(RuntimeEnvironment.application.getApplicationContext());
@@ -145,6 +147,7 @@ public class ComScoreTest {
     settings.putValue("autoUpdateInterval", 2000);
     settings.putValue("autoUpdate", true);
     settings.putValue("foregroundOnly", true);
+    settings.putValue("consentFlag", "consentFlag");
 
     Mockito.reset(comScoreAnalytics);
     integration = new ComScoreIntegration(analytics, settings, comScoreAnalytics);
@@ -172,6 +175,7 @@ public class ComScoreTest {
     settings.putValue("autoUpdateInterval", null);
     settings.putValue("autoUpdate", false);
     settings.putValue("foregroundOnly", false);
+
 
     integration = new ComScoreIntegration(analytics, settings, comScoreAnalytics);
 


### PR DESCRIPTION
**What does this PR do?**

This PR does the following:
- Adds support of the consent label **cs_ucfr**: allows a customer to map track, screen, identify event property or trait to the _cs_ucfr_ label (comScore user consent flag) in the Destination Settings; converts property value into "1"/"0" as expected by comScore. [PRD here](https://paper.dropbox.com/doc/PRD-Support-for-Comscore-Consent-Flag--BYDdUeruiqATdAIEAAunLmJ4Ag-5Co2TbDeaj0HWqo6rdKra). 
The integration first checks the `properties` object and fallback to `context.traits`. With identify events it checks `traits` object.

**Are there breaking changes in this PR?**
No

**Testing**
Unit testing completed successfully. 
Unit test results: [link](https://drive.google.com/file/d/1FD-fz9lqES047jcsJglodPPqllAso4xT/view?usp=sharing)

![image](https://user-images.githubusercontent.com/27460815/146475138-91593743-cb9c-43ed-89a9-09e83b962a47.png)
![image](https://user-images.githubusercontent.com/27460815/146475177-e0ec58a7-7e94-48a0-a936-227ecdfd6fe2.png)
![image](https://user-images.githubusercontent.com/27460815/146475216-c565aa46-da12-4b01-823a-2ce7feec29f9.png)


**Any background context you want to provide?**
The change was requested by Fox.
cs_ucfr flag was introduced by comScore last year and required for tracking user consent. 
The implementation follows their instructions [in the Android library docs](https://drive.google.com/drive/folders/1aroFZjHQORAfYWv-Ci6yyvH_1rufDicZ) and [consent flag docs](https://www.dropbox.com/s/l6nqlwkgn9ghef3/Collecting_User_Consent-Comscore_Libraries-US%20(1)%20(1)%20(2).pdf?dl=0) 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
We already updated comScore JS integration to support consent flag. [PR here](https://github.com/segmentio/analytics.js-integrations/pull/623). 

Compared to the JS integration - Android integration supports mapping of the top-level properties / context.traits / traits. Nested object mapping is not supported. 
JS integration supports nested properties, and nested context attributes.

IOS integration to be updated next. 

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, it does. 
The `consentFlag` setting is a string field, not required. The setting is live in the Production environment and is already being used by the JS integration. See [here](https://app.segment.com/partner-portal/integration/comscore/settings).
The setting allows a customer to specify track(), screen() or identify() event property/trait name which should be mapped to the cs_ucfr beacon.js label.
If the setting is not populated, or mapped property is missing in the page() call - the integration omits cs_ucfr label. If mapped property value is 1 or true - the integration sets cs_ucfr="1". If mapped property value is 0 or false - the integration sets cs_ucfr="0". If mapped property value is any value other than 1/0/true/false, or if it is Null - the integration sets cs_ucfr="".

**Links to helpful docs and other external resources**
[PRD document](https://paper.dropbox.com/doc/PRD-Support-for-Comscore-Consent-Flag--BYDdUeruiqATdAIEAAunLmJ4Ag-5Co2TbDeaj0HWqo6rdKra)

